### PR TITLE
Use UploadWithContext()

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ONSdigital/dp-healthcheck v1.1.3
 	github.com/ONSdigital/dp-kafka/v2 v2.4.2
 	github.com/ONSdigital/dp-net v1.2.0
-	github.com/ONSdigital/dp-s3 v1.7.0
+	github.com/ONSdigital/dp-s3 v1.8.0
 	github.com/ONSdigital/dp-vault v1.2.0
 	github.com/ONSdigital/log.go/v2 v2.0.9
 	github.com/aws/aws-sdk-go v1.41.4

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/ONSdigital/dp-net v1.0.7/go.mod h1:1QFzx32FwPKD2lgZI6MtcsUXritsBdJihl
 github.com/ONSdigital/dp-net v1.0.12/go.mod h1:2lvIKOlD4T3BjWQwjHhBUO2UNWDk82u/+mHRn0R3C9A=
 github.com/ONSdigital/dp-net v1.2.0 h1:gP9pBt/J8gktYeKsb7hq6uOC2xx1tfvTorUBNXp6pX0=
 github.com/ONSdigital/dp-net v1.2.0/go.mod h1:NinlaqcsPbIR+X7j5PXCl3UI5G2zCL041SDF6WIiiO4=
-github.com/ONSdigital/dp-s3 v1.7.0 h1:ZoHixIZ597TtPI8Uo72qtQ073Jdf7LEAX5lZ1kTDNDQ=
-github.com/ONSdigital/dp-s3 v1.7.0/go.mod h1:kFntfUWr58JGHI8vTNCFvDbgnueoFq+eVUlMqJD/TLU=
+github.com/ONSdigital/dp-s3 v1.8.0 h1:8iWi494emOk1Ri0AaQCndMZ39gYfbMBxAb2aX79nbvE=
+github.com/ONSdigital/dp-s3 v1.8.0/go.mod h1:kFntfUWr58JGHI8vTNCFvDbgnueoFq+eVUlMqJD/TLU=
 github.com/ONSdigital/dp-vault v1.2.0 h1:oRXzVlI11ShMLFu+OnPvpJrpJXi2uGaoysvXwScQZKo=
 github.com/ONSdigital/dp-vault v1.2.0/go.mod h1:GIXMJ6y7OSWN6ayamvAMKqV1/nKdbR5DyEfm6EfiOpU=
 github.com/ONSdigital/go-ns v0.0.0-20191104121206-f144c4ec2e58/go.mod h1:iWos35il+NjbvDEqwtB736pyHru0MPFE/LqcwkV1wDc=

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -128,13 +128,15 @@ func (h *CsvComplete) Handle(ctx context.Context, e *event.CantabularCsvCreated)
 
 	// start creating the excel file
 	excelFile := excelize.NewFile()
-	streamWriter, err := excelFile.NewStreamWriter("Dataset")
+	streamWriter, err := excelFile.NewStreamWriter("Sheet1") // have to start with the one and only default 'Sheet1'
 	if err != nil {
 		return &Error{
 			err:     fmt.Errorf("excel stream writer creation problem"),
 			logData: logData,
 		}
 	}
+	// Now rename to 'Dataset'
+	excelFile.SetSheetName("Sheet1", "Dataset")
 
 	// !!! write header on first sheet, just to demonstrate ... (if its to be kept, add error handling)
 	styleID, err := excelFile.NewStyle(`{"font":{"color":"#EE2277"}}`)
@@ -375,7 +377,7 @@ func (h *CsvComplete) UploadXLSXFile(ctx context.Context, instanceID string, fil
 		// !!! this code needs to use 'UploadWithContext' ???, because when processing an excel file that is
 		// nearly 1million lines it has been seen to take over 45 seconds and if nomad has instructed a service
 		// to shut down gracefully before installing a new version of this app, then this could cause problems.
-		result, err := h.s3.Upload(&s3manager.UploadInput{
+		result, err := h.s3.UploadWithContext(ctx, &s3manager.UploadInput{
 			Body:   file,
 			Bucket: &bucketName,
 			Key:    &filename,
@@ -403,7 +405,7 @@ func (h *CsvComplete) UploadXLSXFile(ctx context.Context, instanceID string, fil
 		// !!! this code needs to use 'UploadWithContext' ???, because when processing an excel file that is
 		// nearly 1million lines it has been seen to take over 45 seconds and if nomad has instructed a service
 		// to shut down gracefully before installing a new version of this app, then this could cause problems.
-		result, err := h.s3.Upload(&s3manager.UploadInput{
+		result, err := h.s3.UploadWithContext(ctx, &s3manager.UploadInput{
 			Body:   file,
 			Bucket: &bucketName,
 			Key:    &filename,

--- a/handler/interface.go
+++ b/handler/interface.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"context"
+
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
 
@@ -11,6 +13,7 @@ import (
 // S3Uploader contains the required method for the S3 Uploader
 type S3Uploader interface {
 	Upload(input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
+	UploadWithContext(ctx context.Context, input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
 	UploadWithPSK(input *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error)
 	BucketName() string
 }

--- a/service/interfaces.go
+++ b/service/interfaces.go
@@ -45,6 +45,7 @@ type HealthChecker interface {
 type S3Uploader interface {
 	Get(key string) (io.ReadCloser, *int64, error)
 	Upload(input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
+	UploadWithContext(ctx context.Context, input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
 	UploadWithPSK(input *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error)
 	BucketName() string
 	Checker(context.Context, *healthcheck.CheckState) error

--- a/service/mock/s3_uploader.go
+++ b/service/mock/s3_uploader.go
@@ -34,6 +34,9 @@ var _ service.S3Uploader = &S3UploaderMock{}
 // 			UploadFunc: func(input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
 // 				panic("mock out the Upload method")
 // 			},
+// 			UploadWithContextFunc: func(ctx context.Context, input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+// 				panic("mock out the UploadWithContext method")
+// 			},
 // 			UploadWithPSKFunc: func(input *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error) {
 // 				panic("mock out the UploadWithPSK method")
 // 			},
@@ -55,6 +58,9 @@ type S3UploaderMock struct {
 
 	// UploadFunc mocks the Upload method.
 	UploadFunc func(input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
+
+	// UploadWithContextFunc mocks the UploadWithContext method.
+	UploadWithContextFunc func(ctx context.Context, input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error)
 
 	// UploadWithPSKFunc mocks the UploadWithPSK method.
 	UploadWithPSKFunc func(input *s3manager.UploadInput, psk []byte) (*s3manager.UploadOutput, error)
@@ -83,6 +89,15 @@ type S3UploaderMock struct {
 			// Options is the options argument value.
 			Options []func(*s3manager.Uploader)
 		}
+		// UploadWithContext holds details about calls to the UploadWithContext method.
+		UploadWithContext []struct {
+			// Ctx is the ctx argument value.
+			Ctx context.Context
+			// Input is the input argument value.
+			Input *s3manager.UploadInput
+			// Options is the options argument value.
+			Options []func(*s3manager.Uploader)
+		}
 		// UploadWithPSK holds details about calls to the UploadWithPSK method.
 		UploadWithPSK []struct {
 			// Input is the input argument value.
@@ -91,11 +106,12 @@ type S3UploaderMock struct {
 			Psk []byte
 		}
 	}
-	lockBucketName    sync.RWMutex
-	lockChecker       sync.RWMutex
-	lockGet           sync.RWMutex
-	lockUpload        sync.RWMutex
-	lockUploadWithPSK sync.RWMutex
+	lockBucketName        sync.RWMutex
+	lockChecker           sync.RWMutex
+	lockGet               sync.RWMutex
+	lockUpload            sync.RWMutex
+	lockUploadWithContext sync.RWMutex
+	lockUploadWithPSK     sync.RWMutex
 }
 
 // BucketName calls BucketNameFunc.
@@ -222,6 +238,45 @@ func (mock *S3UploaderMock) UploadCalls() []struct {
 	mock.lockUpload.RLock()
 	calls = mock.calls.Upload
 	mock.lockUpload.RUnlock()
+	return calls
+}
+
+// UploadWithContext calls UploadWithContextFunc.
+func (mock *S3UploaderMock) UploadWithContext(ctx context.Context, input *s3manager.UploadInput, options ...func(*s3manager.Uploader)) (*s3manager.UploadOutput, error) {
+	if mock.UploadWithContextFunc == nil {
+		panic("S3UploaderMock.UploadWithContextFunc: method is nil but S3Uploader.UploadWithContext was just called")
+	}
+	callInfo := struct {
+		Ctx     context.Context
+		Input   *s3manager.UploadInput
+		Options []func(*s3manager.Uploader)
+	}{
+		Ctx:     ctx,
+		Input:   input,
+		Options: options,
+	}
+	mock.lockUploadWithContext.Lock()
+	mock.calls.UploadWithContext = append(mock.calls.UploadWithContext, callInfo)
+	mock.lockUploadWithContext.Unlock()
+	return mock.UploadWithContextFunc(ctx, input, options...)
+}
+
+// UploadWithContextCalls gets all the calls that were made to UploadWithContext.
+// Check the length with:
+//     len(mockedS3Uploader.UploadWithContextCalls())
+func (mock *S3UploaderMock) UploadWithContextCalls() []struct {
+	Ctx     context.Context
+	Input   *s3manager.UploadInput
+	Options []func(*s3manager.Uploader)
+} {
+	var calls []struct {
+		Ctx     context.Context
+		Input   *s3manager.UploadInput
+		Options []func(*s3manager.Uploader)
+	}
+	mock.lockUploadWithContext.RLock()
+	calls = mock.calls.UploadWithContext
+	mock.lockUploadWithContext.RUnlock()
 	return calls
 }
 


### PR DESCRIPTION
### What

Use UploadWithContext for unencrypted files so that app can be made to exit when doing a long running upload

### How to review

Visual inspection.
Check Tests run OK.

### Who can review

Anyone
