### PR TITLE
Do garbage collection after every export

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -146,6 +147,8 @@ func (h *CsvComplete) Handle(ctx context.Context, e *event.CantabularCsvCreated)
 		// to do with the meaning of the word 'streaming'.
 		doLargeSheet = false
 	}
+
+	defer runtime.GC()
 
 	// start creating the excel file in its "in memory structure"
 	excelInMemoryStructure := excelize.NewFile()


### PR DESCRIPTION
### What

Memory usage grows a lot for large csv files and seems to persist and grow more for next export.
Adding call to garbage collector helps to bring allocations back down.

### How to review

Visual inspection

### Who can review

Anyone.