### PR TITLE
Run docker-compose as host user

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 BINPATH ?= build
 
+MY_UID=$(shell id -u)
+MY_GID=$(shell id -g)
 BUILD_TIME=$(shell date +%s)
 GIT_COMMIT=$(shell git rev-parse HEAD)
 VERSION ?= $(shell git tag --points-at HEAD | grep ^v | head -n 1)
@@ -50,7 +52,7 @@ convey:
 
 .PHONY: test-component
 test-component:
-	cd features/compose; docker-compose up --abort-on-container-exit
+	cd features/compose && MY_UID=$(MY_UID) MY_GID=$(MY_GID) docker-compose up --abort-on-container-exit
 
 .PHONY: lint
 lint:

--- a/features/compose/dp-cantabular-xlsx-exporter.yml
+++ b/features/compose/dp-cantabular-xlsx-exporter.yml
@@ -4,6 +4,7 @@ services:
         build:
             context: ../../../dp-cantabular-xlsx-exporter
             dockerfile: Dockerfile.local
+        user: "${MY_UID}:${MY_UID}"
         command:
             - go 
             - test 


### PR DESCRIPTION
### What

When creating the `.go` volume on a Linux host machine it was being created
using the default user, i.e, root.

This is not advisable as it will force the host user to either change
the permissions of the `.go` folder, run `sudo make test-component` or
delete the `.go` for subsquent executions.

Also we should not allow the default root user to create volumes on our
host machines as it is a security risk.

### How to review

Run: 

```
make test-component
```

### Who can review

Anyone
