### PR TITLE
changed dimensionIds to dimensions as we are using names

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -7,5 +7,5 @@ type CantabularCsvCreated struct {
 	Edition    string   `avro:"edition"`
 	Version    string   `avro:"version"`
 	RowCount   int32    `avro:"row_count"`
-	Dimensions []string `avro:"dimension_ids"`
+	Dimensions []string `avro:"dimensions"`
 }

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -14,7 +14,7 @@ var cantabularCsvCreated = `{
     {"name": "version", "type": "string", "default": ""},
     {"name": "row_count", "type": "int", "default": 0},
     {
-      "name": "dimension_ids",
+      "name": "dimensions",
       "type": {
         "type": "array", 
         "items": {


### PR DESCRIPTION
### What
US: https://trello.com/c/vSxzIedn/5674-update-dp-cantabular-metadata-exporter-to-support-export-based-on-specific-dimensions
Variable and schema for kafka changed to reflect that it is a name and not id

### How to review


### Who can review

Anyone
