### PR TITLE
5863 Fix cell formatting with commas in the text

### DIFF
--- a/features/dp-cantabular-xlsx-exporter-published.feature
+++ b/features/dp-cantabular-xlsx-exporter-published.feature
@@ -13,6 +13,7 @@ Feature: Cantabular-Xlsx-Exporter-Published
       0,London,1 or 2 siblings,Female
       0,London,3 or more siblings,Male
       1,London,3 or more siblings,Female
+      1,London,"3,4,5 or more siblings",Female
       0,Liverpool,No siblings,Male
       0,Liverpool,No siblings,Female
       0,Liverpool,1 or 2 siblings,Male

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bufio"
 	"context"
+	"encoding/csv"
 	"encoding/hex"
 	"fmt"
 	"io"
@@ -292,10 +293,15 @@ func (h *XlsxCreate) GetCSVtoExcelStructure(ctx context.Context, excelInMemorySt
 		}
 
 		incomingCsvRow++
-		line := scanner.Text()
 
-		// split 'line' and do the Excel write at 'row' & deal with any errors
-		columns := strings.Split(line, ",")
+		cr := csv.NewReader(strings.NewReader(scanner.Text()))
+		columns, err := cr.Read()
+		if err != nil {
+			return &Error{err: errors.Wrapf(err, "error parsing csv row records/cells at row %d", incomingCsvRow),
+				logData: log.Data{"event": event, "bucketName": bucketName, "filenameCsv": filenameCsv},
+			}
+		}
+
 		nofColumns := len(columns)
 		if nofColumns == 0 {
 			return &Error{err: errors.Wrapf(err, "downloaded .csv file has no columns at row %d", incomingCsvRow),


### PR DESCRIPTION
### What

When a CSV value contained a comma as part of it's text the XLS operation was splitting the row on ',' and creating extra columns.

The solution is to use the Go built in `csv.NewReader` operation to interpret a csv row/line. This would account for other characters/runes inside the CSV value.

Resolves: [5863](https://trello.com/c/Qgo1BD5G/5863-fix-text-formatting-in-excel-download)

### How to review

* Sense check it
* Ensure tests are :green_circle:

### Who can review

Any ONS developer.
