### PR TITLE
Release/2.10.0

### DIFF
--- a/features/dp-cantabular-xlsx-exporter-private.feature
+++ b/features/dp-cantabular-xlsx-exporter-private.feature
@@ -391,5 +391,5 @@ Feature: Cantabular-Xlsx-Exporter-Published
 
     And a private file with filename "datasets/dataset-happy-01-edition-happy-01-version-happy-01.xlsx" can be seen in minio
     
-    And the "xlsx" download in "filterOutputs" with key "id" value "filterOutput-happy-01" is updated with "datasets/dataset-happy-01-edition-happy-01-version-happy-01.xlsx"
+    And the "xls" download in "filterOutputs" with key "id" value "filterOutput-happy-01" is updated with "datasets/dataset-happy-01-edition-happy-01-version-happy-01.xlsx"
     

--- a/features/dp-cantabular-xlsx-exporter-published.feature
+++ b/features/dp-cantabular-xlsx-exporter-published.feature
@@ -392,5 +392,5 @@ And I have these filter outputs:
 
     And a public file with filename "datasets/dataset-happy-01-edition-happy-01-version-happy-01.xlsx" can be seen in minio
 
-    And the "xlsx" download in "filterOutputs" with key "id" value "filterOutput-happy-01" is updated with "datasets/dataset-happy-01-edition-happy-01-version-happy-01.xlsx"
+    And the "xls" download in "filterOutputs" with key "id" value "filterOutput-happy-01" is updated with "datasets/dataset-happy-01-edition-happy-01-version-happy-01.xlsx"
     

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -616,7 +616,7 @@ func (h *XlsxCreate) UpdateFilterOutput(ctx context.Context, filterOutputID stri
 
 	m := filter.Model{
 		Downloads: map[string]filter.Download{
-			"XLSX": download,
+			"XLS": download,
 		},
 		IsPublished: isPublished,
 	}
@@ -658,7 +658,7 @@ func (h *XlsxCreate) UpdateInstance(ctx context.Context, event *event.Cantabular
 
 	versionUpdate := dataset.Version{
 		Downloads: map[string]dataset.Download{
-			"XLSX": *xlsxDownload,
+			"XLS": *xlsxDownload,
 		},
 	}
 

--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -221,7 +221,7 @@ func TestUpdateInstance(t *testing.T) {
 				So(datasetAPIMock.PutVersionCalls()[0].Version, ShouldEqual, testVersion)
 				So(datasetAPIMock.PutVersionCalls()[0].M, ShouldResemble, dataset.Version{
 					Downloads: map[string]dataset.Download{
-						"XLSX": {
+						"XLS": {
 							URL:  expectedURL,
 							Size: fmt.Sprintf("%d", testSize),
 						},
@@ -246,7 +246,7 @@ func TestUpdateInstance(t *testing.T) {
 				So(datasetAPIMock.PutVersionCalls()[0].Version, ShouldEqual, testVersion)
 				So(datasetAPIMock.PutVersionCalls()[0].M, ShouldResemble, dataset.Version{
 					Downloads: map[string]dataset.Download{
-						"XLSX": {
+						"XLS": {
 							Public: fmt.Sprintf("/datasets/%s.xlsx", testVersion),
 							URL:    expectedURL,
 							Size:   fmt.Sprintf("%d", testSize),


### PR DESCRIPTION
### What

- [get all dimensions from cantabular for multivariate metadata](https://github.com/ONSdigital/dp-cantabular-xlsx-exporter/commit/5774e76328ee17784f64a19bc74b04ffbf8ae0df)
- [Obfuscate minio access keys in config](https://github.com/ONSdigital/dp-cantabular-xlsx-exporter/commit/c208c0dfe0be79f69b1c5cd7545c00724e3e1958)
- [update file name for filtered downloads](https://github.com/ONSdigital/dp-cantabular-xlsx-exporter/commit/30446c396eb79b2b2e7d5bd6b82520d36e4f9087)
- [revert xls changes](https://github.com/ONSdigital/dp-cantabular-xlsx-exporter/commit/7ecb9bdf6ddca4578952f5a7e322fbd395af7a58)

### How to review

Confirm no unexpected commits and tests pass

### Who can review

Anyone
